### PR TITLE
Add Hoc and Render Prop conversion methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ import {
   fromRenderProp,
   RenderPropsComponent,
   RenderPropsProps,
+  fromHigherOrderComponent,
+  toRenderProp,
+  toHigherOrderComponent,
 } from './ChainableComponent';
 import { withPromise, WithPromise } from './lib/withPromise';
 import { withState, WithState } from './lib/withState';
@@ -14,6 +17,9 @@ export {
   RenderPropsComponent,
   fromRenderProp,
   fromRender,
+  toRenderProp,
+  fromHigherOrderComponent,
+  toHigherOrderComponent,
   withState, WithState,
   withPromise, WithPromise,
 };


### PR DESCRIPTION
The purpose of this pull request is to add the ability to convert chainable components to higher order component and render prop components and vice versa

Instead of rendering a react node directly in the render method:
```javascript
const withState1 = withState({ initial : 42 })
const withState2 = withState({ initial : 23 })

const Chained = Chainable.all([ withState1, withState2 ])

const Component = props => 
<div>
{ Chained.render( ([s1, s2]) => <div>Sum: {s1.value + s2.value}</div> ) }
</div>
```

A user can easily export to a renderProp and use the more familiar
```javascript
const withState1 = withState({ initial : 42 })
const withState2 = withState({ initial : 23 })

const Chained = Chainable.all([ withState1, withState2 ]).toRenderProp()

const Component = props => 
<Chained>
{ ([s1, s2]) => <div>Sum: {s1.value + s2.value}</div> } 
</Chained
```